### PR TITLE
feat: auto add url and slash

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,19 @@ hexo.extend.generator.register('robotstxt', function(locals){
 			}
 
 			if( cfg.sitemap ) {
-				cfg.sitemap.forEach(function(entry) {
-				    body += "Sitemap: " + entry + "\n";
+				cfg.sitemap.forEach(function (entry) {
+					let sitemap = "Sitemap: ";
+					if (entry.startsWith("http")) {
+						sitemap += entry + "\n";
+					} else {
+						const slash =
+							hexo.config.url.endsWith("/") ||
+							entry.startsWith("/")
+								? ""
+								: "/";
+						sitemap += hexo.config.url + slash + entry + "\n";
+					}
+					body += sitemap;
 				});
 			}
 


### PR DESCRIPTION
According to [Google's rule](https://developers.google.com/search/docs/crawling-indexing/robots/create-robots-txt#create_rules):

> **Google's crawlers support the following rules in robots.txt files:**
> - sitemap: [Optional, zero or more per file] The location of a sitemap for this website. The sitemap URL must be a fully-qualified URL; Google doesn't assume or check http/https/www.non-www alternates. Sitemaps are a good way to indicate which content Google should crawl, as opposed to which content it can or cannot crawl. [Learn more about sitemaps.](https://developers.google.com/search/docs/crawling-indexing/sitemaps/overview) Example:
> ```txt
> Sitemap: https://example.com/sitemap.xml
> Sitemap: https://www.example.com/sitemap.xml
> ```

which said a valid sitemap must be a fully-qualified URL.
